### PR TITLE
Fill connection handle in Gatt callbacks parameters

### DIFF
--- a/source/btle/btle_discovery.cpp
+++ b/source/btle/btle_discovery.cpp
@@ -56,10 +56,11 @@ void bleGattcEventHandler(const ble_evt_t *p_ble_evt)
 
         case BLE_GATTC_EVT_READ_RSP: {
                 GattReadCallbackParams response = {
-                    .handle = p_ble_evt->evt.gattc_evt.params.read_rsp.handle,
-                    .offset = p_ble_evt->evt.gattc_evt.params.read_rsp.offset,
-                    .len    = p_ble_evt->evt.gattc_evt.params.read_rsp.len,
-                    .data   = p_ble_evt->evt.gattc_evt.params.read_rsp.data,
+                    .connHandle = p_ble_evt->evt.gattc_evt.conn_handle,
+                    .handle     = p_ble_evt->evt.gattc_evt.params.read_rsp.handle,
+                    .offset     = p_ble_evt->evt.gattc_evt.params.read_rsp.offset,
+                    .len        = p_ble_evt->evt.gattc_evt.params.read_rsp.len,
+                    .data       = p_ble_evt->evt.gattc_evt.params.read_rsp.data,
                 };
                 nRF5xGattClient::getInstance().processReadResponse(&response);
             }
@@ -67,11 +68,12 @@ void bleGattcEventHandler(const ble_evt_t *p_ble_evt)
 
         case BLE_GATTC_EVT_WRITE_RSP: {
                 GattWriteCallbackParams response = {
-                    .handle  = p_ble_evt->evt.gattc_evt.params.write_rsp.handle,
-                    .writeOp = (GattWriteCallbackParams::WriteOp_t)(p_ble_evt->evt.gattc_evt.params.write_rsp.write_op),
-                    .offset  = p_ble_evt->evt.gattc_evt.params.write_rsp.offset,
-                    .len     = p_ble_evt->evt.gattc_evt.params.write_rsp.len,
-                    .data    = p_ble_evt->evt.gattc_evt.params.write_rsp.data,
+                    .connHandle = p_ble_evt->evt.gattc_evt.conn_handle,
+                    .handle     = p_ble_evt->evt.gattc_evt.params.write_rsp.handle,
+                    .writeOp    = (GattWriteCallbackParams::WriteOp_t)(p_ble_evt->evt.gattc_evt.params.write_rsp.write_op),
+                    .offset     = p_ble_evt->evt.gattc_evt.params.write_rsp.offset,
+                    .len        = p_ble_evt->evt.gattc_evt.params.write_rsp.len,
+                    .data       = p_ble_evt->evt.gattc_evt.params.write_rsp.data,
                 };
                 nRF5xGattClient::getInstance().processWriteResponse(&response);
             }
@@ -79,10 +81,11 @@ void bleGattcEventHandler(const ble_evt_t *p_ble_evt)
 
         case BLE_GATTC_EVT_HVX: {
                 GattHVXCallbackParams params;
-                params.handle = p_ble_evt->evt.gattc_evt.params.hvx.handle;
-                params.type   = static_cast<HVXType_t>(p_ble_evt->evt.gattc_evt.params.hvx.type);
-                params.len    = p_ble_evt->evt.gattc_evt.params.hvx.len;
-                params.data   = p_ble_evt->evt.gattc_evt.params.hvx.data;
+                params.connHandle = p_ble_evt->evt.gattc_evt.conn_handle;
+                params.handle     = p_ble_evt->evt.gattc_evt.params.hvx.handle;
+                params.type       = static_cast<HVXType_t>(p_ble_evt->evt.gattc_evt.params.hvx.type);
+                params.len        = p_ble_evt->evt.gattc_evt.params.hvx.len;
+                params.data       = p_ble_evt->evt.gattc_evt.params.hvx.data;
 
                 nRF5xGattClient::getInstance().processHVXEvent(&params);
             }

--- a/source/nRF5xGattServer.cpp
+++ b/source/nRF5xGattServer.cpp
@@ -375,21 +375,23 @@ void nRF5xGattServer::hwCallback(ble_evt_t *p_ble_evt)
     switch (eventType) {
         case GattServerEvents::GATT_EVENT_DATA_WRITTEN: {
             GattWriteCallbackParams cbParams = {
-                .handle  = handle_value,
-                .writeOp = static_cast<GattWriteCallbackParams::WriteOp_t>(gattsEventP->params.write.op),
-                .offset  = gattsEventP->params.write.offset,
-                .len     = gattsEventP->params.write.len,
-                .data    = gattsEventP->params.write.data
+                .connHandle = gattsEventP->conn_handle,
+                .handle     = handle_value,
+                .writeOp    = static_cast<GattWriteCallbackParams::WriteOp_t>(gattsEventP->params.write.op),
+                .offset     = gattsEventP->params.write.offset,
+                .len        = gattsEventP->params.write.len,
+                .data       = gattsEventP->params.write.data
             };
             handleDataWrittenEvent(&cbParams);
             break;
         }
         case GattServerEvents::GATT_EVENT_WRITE_AUTHORIZATION_REQ: {
             GattWriteAuthCallbackParams cbParams = {
-                .handle  = handle_value,
-                .offset  = gattsEventP->params.authorize_request.request.write.offset,
-                .len     = gattsEventP->params.authorize_request.request.write.len,
-                .data    = gattsEventP->params.authorize_request.request.write.data,
+                .connHandle = gattsEventP->conn_handle,
+                .handle     = handle_value,
+                .offset     = gattsEventP->params.authorize_request.request.write.offset,
+                .len        = gattsEventP->params.authorize_request.request.write.len,
+                .data       = gattsEventP->params.authorize_request.request.write.data,
             };
             ble_gatts_rw_authorize_reply_params_t reply = {
                 .type = BLE_GATTS_AUTHORIZE_TYPE_WRITE,
@@ -410,11 +412,12 @@ void nRF5xGattServer::hwCallback(ble_evt_t *p_ble_evt)
              */
             if (reply.params.write.gatt_status == BLE_GATT_STATUS_SUCCESS) {
                 GattWriteCallbackParams cbParams = {
-                    .handle  = handle_value,
-                    .writeOp = static_cast<GattWriteCallbackParams::WriteOp_t>(gattsEventP->params.authorize_request.request.write.op),
-                    .offset  = gattsEventP->params.authorize_request.request.write.offset,
-                    .len     = gattsEventP->params.authorize_request.request.write.len,
-                    .data    = gattsEventP->params.authorize_request.request.write.data,
+                    .connHandle = gattsEventP->conn_handle,
+                    .handle     = handle_value,
+                    .writeOp    = static_cast<GattWriteCallbackParams::WriteOp_t>(gattsEventP->params.authorize_request.request.write.op),
+                    .offset     = gattsEventP->params.authorize_request.request.write.offset,
+                    .len        = gattsEventP->params.authorize_request.request.write.len,
+                    .data       = gattsEventP->params.authorize_request.request.write.data,
                 };
                 handleDataWrittenEvent(&cbParams);
             }
@@ -422,10 +425,11 @@ void nRF5xGattServer::hwCallback(ble_evt_t *p_ble_evt)
         }
         case GattServerEvents::GATT_EVENT_READ_AUTHORIZATION_REQ: {
             GattReadAuthCallbackParams cbParams = {
-                .handle = handle_value,
-                .offset = gattsEventP->params.authorize_request.request.read.offset,
-                .len    = 0,
-                .data   = NULL
+                .connHandle = gattsEventP->conn_handle,
+                .handle     = handle_value,
+                .offset     = gattsEventP->params.authorize_request.request.read.offset,
+                .len        = 0,
+                .data       = NULL
             };
 
             ble_gatts_rw_authorize_reply_params_t reply = {


### PR DESCRIPTION
This commit implements the nRF51 side of this pull request in ble API: https://github.com/ARMmbed/ble/pull/67