### PR TITLE
Disable GattClient features when using S110 SoftDevice

### DIFF
--- a/source/btle/btle.cpp
+++ b/source/btle/btle.cpp
@@ -107,7 +107,9 @@ static void btle_handler(ble_evt_t *p_ble_evt)
 
     dm_ble_evt_handler(p_ble_evt);
 
+#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
     bleGattcEventHandler(p_ble_evt);
+#endif
 
     /* Custom event handler */
     switch (p_ble_evt->header.evt_id) {

--- a/source/btle/btle_discovery.cpp
+++ b/source/btle/btle_discovery.cpp
@@ -17,6 +17,7 @@
 #include "nRF5xServiceDiscovery.h"
 #include "nRF5xGattClient.h"
 
+#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
 void bleGattcEventHandler(const ble_evt_t *p_ble_evt)
 {
     nRF5xServiceDiscovery &sdSingleton = nRF5xGattClient::getInstance().discovery;
@@ -92,4 +93,5 @@ void bleGattcEventHandler(const ble_evt_t *p_ble_evt)
     sdSingleton.progressCharacteristicDiscovery();
     sdSingleton.progressServiceDiscovery();
 }
+#endif
 

--- a/source/nRF5xGap.h
+++ b/source/nRF5xGap.h
@@ -80,6 +80,8 @@ public:
         return BLE_ERROR_UNSPECIFIED;
     }
 
+/* Observer role is not supported by S110, return BLE_ERROR_NOT_IMPLEMENTED */
+#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
     virtual ble_error_t startRadioScan(const GapScanningParams &scanningParams) {
         ble_gap_scan_params_t scanParams = {
             .active      = scanningParams.getActiveScanning(), /**< If 1, perform active scanning (scan requests). */
@@ -104,6 +106,7 @@ public:
 
         return BLE_STACK_BUSY;
     }
+#endif
 
 private:
     /**

--- a/source/nRF5xGattClient.cpp
+++ b/source/nRF5xGattClient.cpp
@@ -23,6 +23,7 @@ nRF5xGattClient::getInstance(void) {
     return nRFGattClientSingleton;
 }
 
+#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
 ble_error_t
 nRF5xGattClient::launchServiceDiscovery(Gap::Handle_t                               connectionHandle,
                                         ServiceDiscovery::ServiceCallback_t         sc,
@@ -32,3 +33,4 @@ nRF5xGattClient::launchServiceDiscovery(Gap::Handle_t                           
 {
     return discovery.launch(connectionHandle, sc, cc, matchingServiceUUIDIn, matchingCharacteristicUUIDIn);
 }
+#endif

--- a/source/nRF5xGattClient.h
+++ b/source/nRF5xGattClient.h
@@ -26,6 +26,12 @@ public:
     static nRF5xGattClient &getInstance();
 
     /**
+     * When using S110, all Gatt client features will return
+     * BLE_ERROR_NOT_IMPLEMENTED
+     */
+#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
+
+    /**
      * Launch service discovery. Once launched, service discovery will remain
      * active with callbacks being issued back into the application for matching
      * services/characteristics. isActive() can be used to determine status; and
@@ -152,6 +158,8 @@ private:
 
 private:
     nRF5xServiceDiscovery discovery;
+
+#endif // if !S110
 };
 
 #endif // ifndef __NRF51822_GATT_CLIENT_H__


### PR DESCRIPTION
S110 compatibility is already present, but this patch adds proper handling
of observer/central related features:
* Gap::startScan will return BLE_ERRROR_NOT_IMPLEMENTED (instead of
  PARAM_OUT_OF_RANGE)
* nRF5xGattClient uses the default GattClient implementation when S110 is
  in use. All if its methods return NOT_IMPLEMENTED.

Example: for an application that acts as both a central and a peripheral,
using S110 will make the ble.gap().startScan() call return
BLE_ERROR_NOT_IMPLEMENTED, and advertisement features will continue
running normally.
In addition, with GCC, this patch will free 344 bytes of RAM and 2504
bytes of flash.