### PR TITLE
Update S110 detection macros

### DIFF
--- a/source/btle/btle.cpp
+++ b/source/btle/btle.cpp
@@ -133,7 +133,7 @@ static void btle_handler(ble_evt_t *p_ble_evt)
 
     dm_ble_evt_handler(p_ble_evt);
 
-#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
+#if !defined(MCU_NRF51_16K_S110) && !defined(MCU_NRF51_32K_S110)
     bleGattcEventHandler(p_ble_evt);
 #endif
 
@@ -141,7 +141,7 @@ static void btle_handler(ble_evt_t *p_ble_evt)
     switch (p_ble_evt->header.evt_id) {
         case BLE_GAP_EVT_CONNECTED: {
             Gap::Handle_t handle = p_ble_evt->evt.gap_evt.conn_handle;
-#if defined(MCU_NORDIC_16K_S110) || defined(MCU_NORDIC_32K_S110)
+#if defined(MCU_NRF51_16K_S110) || defined(MCU_NRF51_32K_S110)
             /* Only peripheral role is supported by S110 */
             Gap::Role_t role = Gap::PERIPHERAL;
 #else

--- a/source/btle/btle_discovery.cpp
+++ b/source/btle/btle_discovery.cpp
@@ -17,7 +17,7 @@
 #include "nRF5xServiceDiscovery.h"
 #include "nRF5xGattClient.h"
 
-#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
+#if !defined(MCU_NRF51_16K_S110) && !defined(MCU_NRF51_32K_S110)
 void bleGattcEventHandler(const ble_evt_t *p_ble_evt)
 {
     nRF5xServiceDiscovery &sdSingleton = nRF5xGattClient::getInstance().discovery;

--- a/source/nRF5xGap.h
+++ b/source/nRF5xGap.h
@@ -81,7 +81,7 @@ public:
     }
 
 /* Observer role is not supported by S110, return BLE_ERROR_NOT_IMPLEMENTED */
-#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
+#if !defined(MCU_NRF51_16K_S110) && !defined(MCU_NRF51_32K_S110)
     virtual ble_error_t startRadioScan(const GapScanningParams &scanningParams) {
         ble_gap_scan_params_t scanParams = {
             .active      = scanningParams.getActiveScanning(), /**< If 1, perform active scanning (scan requests). */

--- a/source/nRF5xGattClient.cpp
+++ b/source/nRF5xGattClient.cpp
@@ -22,7 +22,7 @@ nRF5xGattClient::getInstance(void) {
     return nRFGattClientSingleton;
 }
 
-#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
+#if !defined(MCU_NRF51_16K_S110) && !defined(MCU_NRF51_32K_S110)
 ble_error_t
 nRF5xGattClient::launchServiceDiscovery(Gap::Handle_t                               connectionHandle,
                                         ServiceDiscovery::ServiceCallback_t         sc,

--- a/source/nRF5xGattClient.h
+++ b/source/nRF5xGattClient.h
@@ -29,7 +29,7 @@ public:
      * When using S110, all Gatt client features will return
      * BLE_ERROR_NOT_IMPLEMENTED
      */
-#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
+#if !defined(MCU_NRF51_16K_S110) && !defined(MCU_NRF51_32K_S110)
 
     /**
      * Launch service discovery. Once launched, service discovery will remain

--- a/source/nordic-sdk/components/softdevice/s130/include/ble_gap.h
+++ b/source/nordic-sdk/components/softdevice/s130/include/ble_gap.h
@@ -547,7 +547,7 @@ typedef struct
 {
   ble_gap_addr_t        peer_addr;              /**< Bluetooth address of the peer device. */
   ble_gap_addr_t        own_addr;               /**< Bluetooth address of the local device used during connection setup. */
-#if !defined(MCU_NORDIC_16K_S110) && !defined(MCU_NORDIC_32K_S110)
+#if !defined(MCU_NRF51_16K_S110) && !defined(MCU_NRF51_32K_S110)
   uint8_t               role;                   /**< BLE role for this connection, see @ref BLE_GAP_ROLES */
 #endif
   uint8_t               irk_match :1;           /**< If 1, peer device's address resolved using an IRK. */


### PR DESCRIPTION
Those macros are defined by mbed SDK in targets.py. They changed from
MCU_NORDIC_xxx_S110 to MCU_NRF51_xxx_S110. Update the #ifdefs accordingly.