### PR TITLE
rgrover patch fixed

### DIFF
--- a/source/nRF5xGattServer.cpp
+++ b/source/nRF5xGattServer.cpp
@@ -223,8 +223,7 @@ ble_error_t nRF5xGattServer::write(Gap::Handle_t connectionHandle, GattAttribute
 
     int characteristicIndex = resolveValueHandleToCharIndex(attributeHandle);
     if ((characteristicIndex != -1) &&
-        (p_characteristics[characteristicIndex]->getProperties() & (GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_INDICATE | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY)) &&
-        (gapConnectionHandle != connectionHandle)) {
+        (p_characteristics[characteristicIndex]->getProperties() & (GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_INDICATE | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY))) {
         /* HVX update for the characteristic value */
         ble_gatts_hvx_params_t hvx_params;
 
@@ -234,23 +233,29 @@ ble_error_t nRF5xGattServer::write(Gap::Handle_t connectionHandle, GattAttribute
         hvx_params.offset = 0;
         hvx_params.p_data = const_cast<uint8_t *>(buffer);
         hvx_params.p_len  = &len;
-
+        
         error_t error = (error_t) sd_ble_gatts_hvx(gapConnectionHandle, &hvx_params);
-
-        /* ERROR_INVALID_STATE, ERROR_BUSY, ERROR_GATTS_SYS_ATTR_MISSING and ERROR_NO_TX_BUFFERS the ATT table has been updated. */
-        if ((error != ERROR_NONE) && (error != ERROR_INVALID_STATE) && (error != ERROR_BLE_NO_TX_BUFFERS) && (error != ERROR_BUSY) && (error != ERROR_BLEGATTS_SYS_ATTR_MISSING)) {
-            ASSERT_INT( ERROR_NONE,
-                        sd_ble_gatts_value_set(connectionHandle, attributeHandle, &value),
-                        BLE_ERROR_PARAM_OUT_OF_RANGE );
-        }
-
-        /*  Notifications consume application buffers. The return value can
-            be used for resending notifications.
-        */
         if (error != ERROR_NONE) {
-            returnValue = BLE_STACK_BUSY;
+            switch (error) {
+                case ERROR_BLE_NO_TX_BUFFERS: /*  Notifications consume application buffers. The return value can be used for resending notifications. */
+                case ERROR_BUSY:
+                    returnValue = BLE_STACK_BUSY;
+                    break;
+
+                case ERROR_INVALID_STATE:
+                case ERROR_BLEGATTS_SYS_ATTR_MISSING:
+                    returnValue = BLE_ERROR_INVALID_STATE;
+                    break;
+
+                default :
+                    ASSERT_INT( ERROR_NONE,
+                                sd_ble_gatts_value_set(connectionHandle, attributeHandle, &value),
+                                BLE_ERROR_PARAM_OUT_OF_RANGE );
+                    break;
+            }
         }
     } else {
+        returnValue = BLE_ERROR_INVALID_STATE; // if assert is not used
         ASSERT_INT( ERROR_NONE,
                     sd_ble_gatts_value_set(connectionHandle, attributeHandle, &value),
                     BLE_ERROR_PARAM_OUT_OF_RANGE );


### PR DESCRIPTION
your patch fixed (works with gapConnectionHandle)

sd_ble_gatts_hvx still wrong sometimes on triangle test exemple but it looks like a s130 issue.