### PR TITLE
Introduced changes for memory savings

### DIFF
--- a/source/btle/custom/custom_helper.cpp
+++ b/source/btle/custom/custom_helper.cpp
@@ -26,7 +26,7 @@ typedef struct {
     UUID::LongUUIDBytes_t uuid;
     uint8_t         type;
 } converted_uuid_table_entry_t;
-static const unsigned UUID_TABLE_MAX_ENTRIES = 8; /* This is the maximum number of 128-bit UUIDs with distinct bases that
+static const unsigned UUID_TABLE_MAX_ENTRIES = 4; /* This is the maximum number of 128-bit UUIDs with distinct bases that
                                                    * we expect to be in use; increase this limit if needed. */
 static unsigned uuidTableEntries = 0; /* current usage of the table */
 converted_uuid_table_entry_t convertedUUIDTable[UUID_TABLE_MAX_ENTRIES];

--- a/source/nRF5xGattClient.cpp
+++ b/source/nRF5xGattClient.cpp
@@ -18,8 +18,11 @@
 
 nRF5xGattClient &
 nRF5xGattClient::getInstance(void) {
-    static nRF5xGattClient nRFGattClientSingleton;
-    return nRFGattClientSingleton;
+    static nRF5xGattClient* nRFGattClientSingleton = NULL;
+    if (nRFGattClientSingleton == NULL) {
+        nRFGattClientSingleton = new nRF5xGattClient();
+    }
+    return *nRFGattClientSingleton;
 }
 
 #if !defined(TARGET_MCU_NRF51_16K_S110) && !defined(TARGET_MCU_NRF51_32K_S110)

--- a/source/nRF5xSecurityManager.cpp
+++ b/source/nRF5xSecurityManager.cpp
@@ -17,6 +17,9 @@
 #include "nRF5xSecurityManager.h"
 
 nRF5xSecurityManager &nRF5xSecurityManager::getInstance(void) {
-    static nRF5xSecurityManager m_instance;
-    return m_instance;
+    static nRF5xSecurityManager* m_instance = NULL;
+    if (m_instance == NULL) {
+        m_instance = new nRF5xSecurityManager();
+    }
+    return *m_instance;
 }

--- a/source/nordic-sdk/components/ble/device_manager/config/device_manager_cnfg.h
+++ b/source/nordic-sdk/components/ble/device_manager/config/device_manager_cnfg.h
@@ -85,7 +85,7 @@
  *       be stored. In such cases, application will be notified with DM_DEVICE_CONTEXT_FULL 
  *       as event result at the completion of the security procedure.
  */
-#define DEVICE_MANAGER_MAX_BONDS         4
+#define DEVICE_MANAGER_MAX_BONDS         2
 
 
 /**


### PR DESCRIPTION
Moved GattSecurityManager and GattClient to be allocated dynamically and
reduced the size of some arrays to increase memory savings.