### PR TITLE
Ensure that the initialization flags is set to false if the BLE stack is shutdown properly.

### DIFF
--- a/source/nRF5xn.cpp
+++ b/source/nRF5xn.cpp
@@ -104,7 +104,12 @@ ble_error_t nRF5xn::shutdown(void)
         return BLE_ERROR_INITIALIZATION_INCOMPLETE;
     }
 
-    return (softdevice_handler_sd_disable() == NRF_SUCCESS) ? BLE_ERROR_NONE : BLE_STACK_BUSY;
+    if(softdevice_handler_sd_disable() != NRF_SUCCESS) {
+        return BLE_STACK_BUSY;
+    }
+
+    initialized = false;
+    return BLE_ERROR_NONE;
 }
 
 void


### PR DESCRIPTION
Otherwise, once the BLE API has been shutdown, there is no way to initialize it again. Init will always fail.