### PR TITLE
add Nordic's license agreement.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 Many of the files in this module have been inherited from the Nordic SDK for
-nRF51822; they come with a BSD-like license offered by Nordic for use in mbed.
-Some other files come from the mbed SDK, and are licensed under Apache-2.0.
-Unless specifically indicated otherwise in a file, files are licensed
-under the Apache 2.0 license, as can be found in: apache-2.0.txt.
-The BSD-like Nordic license can be found in BSD-3clause-Nordic.txt
+nRF51822. With the exception of the softdevice, they come with a BSD license
+offered by Nordic for use in mbed. The Nordic Softdevice License Agreement, a
+BSD-like licence for binary distributions, applies to the softdevice. Some
+other files come from the mbed SDK, and are licensed under Apache-2.0. Unless
+specifically indicated otherwise in a file, files are licensed under the
+Apache 2.0 license, as can be found in: apache-2.0.txt. The BSD-like Nordic
+license can be found in BSD-3clause-Nordic.txt. The Nordic Semiconductor Softdevice
+License Agreement can be found in softdevice_nrf51822_licence_agreement.txt.

--- a/bootloader/softdevice_nrf51822_licence_agreement.txt
+++ b/bootloader/softdevice_nrf51822_licence_agreement.txt
@@ -1,0 +1,30 @@
+/*
+ * S110/S120/S130 License Agreement
+ *
+ * Copyright (c) 2015, Nordic Semiconductor ASA, All rights reserved.
+ *
+ * Redistribution. Redistribution and use in binary form, without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * • Redistributions must reproduce the above copyright notice and the following
+ *   disclaimer in the documentation and/or other materials provided with the
+ *   distribution.
+ * • Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ * • No reverse engineering, decompilation, or disassembly of this software is
+ *   permitted.
+ *
+ * DISCLAIMER.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * /

--- a/module.json
+++ b/module.json
@@ -18,6 +18,9 @@
     {
       "url": "https://spdx.org/licenses/Apache-2.0",
       "type": "Apache-2.0"
+    },
+    {
+      "type": "LicenseRef-softdevice_nrf51822_licence_agreement.txt"
     }
   ],
   "dependencies": {

--- a/softdevice_nrf51822_licence_agreement.txt
+++ b/softdevice_nrf51822_licence_agreement.txt
@@ -1,0 +1,30 @@
+/*
+ * S110/S120/S130 License Agreement
+ *
+ * Copyright (c) 2015, Nordic Semiconductor ASA, All rights reserved.
+ *
+ * Redistribution. Redistribution and use in binary form, without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * • Redistributions must reproduce the above copyright notice and the following
+ *   disclaimer in the documentation and/or other materials provided with the
+ *   distribution.
+ * • Neither the name of the copyright holder nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ * • No reverse engineering, decompilation, or disassembly of this software is
+ *   permitted.
+ *
+ * DISCLAIMER.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * /


### PR DESCRIPTION
note: we need the softdevice in this module because it is shared with mbed-classic. This is where the mbed-classic toolchain expects to find the SD.

@LiyouZhou 