### PR TITLE
Fixed endianness bug in nRF5xServiceDiscovery::processDiscoverUUIDResponse so it is consistent with BLE API.

### DIFF
--- a/source/nRF5xServiceDiscovery.cpp
+++ b/source/nRF5xServiceDiscovery.cpp
@@ -251,9 +251,9 @@ nRF5xServiceDiscovery::processDiscoverUUIDResponse(const ble_gattc_evt_char_val_
     if (state == DISCOVER_SERVICE_UUIDS) {
         if ((response->count == 1) && (response->value_len == UUID::LENGTH_OF_LONG_UUID)) {
             UUID::LongUUIDBytes_t uuid;
-            /* Switch longUUID bytes to MSB */
+
             for (unsigned i = 0; i < UUID::LENGTH_OF_LONG_UUID; i++) {
-                uuid[i] = response->handle_value[0].p_value[UUID::LENGTH_OF_LONG_UUID - 1 - i];
+                uuid[i] = response->handle_value[0].p_value[i];
             }
 
             unsigned serviceIndex = serviceUUIDDiscoveryQueue.dequeue();
@@ -266,9 +266,9 @@ nRF5xServiceDiscovery::processDiscoverUUIDResponse(const ble_gattc_evt_char_val_
     } else if (state == DISCOVER_CHARACTERISTIC_UUIDS) {
         if ((response->count == 1) && (response->value_len == UUID::LENGTH_OF_LONG_UUID + 1 /* props */ + 2 /* value handle */)) {
             UUID::LongUUIDBytes_t uuid;
-            /* Switch longUUID bytes to MSB */
+
             for (unsigned i = 0; i < UUID::LENGTH_OF_LONG_UUID; i++) {
-                uuid[i] = response->handle_value[0].p_value[3 + UUID::LENGTH_OF_LONG_UUID - 1 - i];
+                uuid[i] = response->handle_value[0].p_value[3 + i];
             }
 
             unsigned charIndex = charUUIDDiscoveryQueue.dequeue();


### PR DESCRIPTION
In BLE::UUID, uuids are stored and handled little endian. This PR preserves the endianness returned by the Nordic Softdevice during discovery.