### PR TITLE
Allow GattAttributes to have variable length

### DIFF
--- a/source/btle/custom/custom_helper.cpp
+++ b/source/btle/custom/custom_helper.cpp
@@ -191,6 +191,8 @@ error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
     @param[in]  char_props        The characteristic properties, as
                                   defined by ble_gatt_char_props_t
     @param[in]  max_length        The maximum length of this characeristic
+    @param[in]  has_variable_len  Whether the characteristic data has
+                                  variable length.
     @param[out] p_char_handle
 
     @returns
@@ -204,6 +206,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      uint8_t                  *p_data,
                                      uint16_t                  length,
                                      uint16_t                  max_length,
+                                     bool                      has_variable_len,
                                      const uint8_t            *userDescriptionDescriptorValuePtr,
                                      uint16_t                  userDescriptionDescriptorValueLen,
                                      bool                      readAuthorization,
@@ -243,7 +246,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
 
     attr_md.vloc = BLE_GATTS_VLOC_STACK;
     /* Always set variable size */
-    attr_md.vlen = 1;
+    attr_md.vlen = has_variable_len;
 
     if (char_props.read || char_props.notify || char_props.indicate) {
         switch (requiredSecurity) {
@@ -318,24 +321,27 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                   since 1 is typically used by the primary
                                   service).
     @param[in]  max_length        The maximum length of this descriptor
+    @param[in]  has_variable_len  Whether the characteristic data has
+                                  variable length.
 
     @returns
     @retval     ERROR_NONE        Everything executed normally
 */
 /**************************************************************************/
 error_t custom_add_in_descriptor(uint16_t    char_handle,
-                                             ble_uuid_t *p_uuid,
-                                             uint8_t    *p_data,
-                                             uint16_t    length,
-                                             uint16_t    max_length,
-                                             uint16_t   *p_desc_handle)
+                                 ble_uuid_t *p_uuid,
+                                 uint8_t    *p_data,
+                                 uint16_t    length,
+                                 uint16_t    max_length,
+                                 bool        has_variable_len,
+                                 uint16_t   *p_desc_handle)
 {
     /* Descriptor metadata */
     ble_gatts_attr_md_t   desc_md = {0};
 
     desc_md.vloc = BLE_GATTS_VLOC_STACK;
     /* Always set variable size */
-    desc_md.vlen = 1;
+    desc_md.vlen = has_variable_len;
 
     /* Make it readable and writable */
     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&desc_md.read_perm);

--- a/source/btle/custom/custom_helper.h
+++ b/source/btle/custom/custom_helper.h
@@ -38,6 +38,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      uint8_t                  *p_data,
                                      uint16_t                  length,
                                      uint16_t                  max_length,
+                                     bool                      has_variable_len,
                                      const uint8_t            *userDescriptionDescriptorValuePtr,
                                      uint16_t                  userDescriptionDescriptorValueLen,
                                      bool                      readAuthorization,
@@ -49,6 +50,7 @@ error_t custom_add_in_descriptor(uint16_t                      char_handle,
                                      uint8_t                  *p_data,
                                      uint16_t                  length,
                                      uint16_t                  max_length,
+                                     bool                      has_variable_len,
                                      uint16_t                 *p_desc_handle);
 
 #ifdef __cplusplus

--- a/source/nRF5xGattServer.cpp
+++ b/source/nRF5xGattServer.cpp
@@ -97,6 +97,7 @@ ble_error_t nRF5xGattServer::addService(GattService &service)
                                               p_char->getValueAttribute().getValuePtr(),
                                               p_char->getValueAttribute().getLength(),
                                               p_char->getValueAttribute().getMaxLength(),
+                                              p_char->getValueAttribute().hasVariableLength(),
                                               userDescriptionDescriptorValuePtr,
                                               userDescriptionDescriptorValueLen,
                                               p_char->isReadAuthorizationEnabled(),
@@ -129,6 +130,7 @@ ble_error_t nRF5xGattServer::addService(GattService &service)
                                             p_desc->getValuePtr(),
                                             p_desc->getLength(),
                                             p_desc->getMaxLength(),
+                                            p_desc->hasVariableLength(),
                                             &nrfDescriptorHandles[descriptorCount]),
                 BLE_ERROR_PARAM_OUT_OF_RANGE);
 


### PR DESCRIPTION
Previously the concepts of initLength and lenth were clearly separated. However, this was at the cost of registering all characteristics in the SoftDevice as having variable length. Clearly, this is not the desired behaviour. Therefore, an additional field '_hasVariableLen' is added to the GattAttribute to address the problem. Also, the GattAttribute and GattCharacteristic constructors have been modified to take a boolean that sets '_hasVariableLen'.

**NOTE:** Changes to this module will cause projects to fail the build stage if changes to the BLE_API are not published first.
@rgrover