### PR TITLE
Replace deprecated inclusions of mbed.h

### DIFF
--- a/source/nRF5xGap.cpp
+++ b/source/nRF5xGap.cpp
@@ -15,7 +15,11 @@
  */
 
 #include "nRF5xn.h"
-#include "mbed.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed.h"
+#else
+    #include "mbed.h"
+#endif
 #include "ble/BLE.h"
 
 #include "common/common.h"

--- a/source/nRF5xGap.h
+++ b/source/nRF5xGap.h
@@ -17,7 +17,11 @@
 #ifndef __NRF5x_GAP_H__
 #define __NRF5x_GAP_H__
 
-#include "mbed.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed.h"
+#else
+    #include "mbed.h"
+#endif
 #include "ble/blecommon.h"
 #include "ble.h"
 #include "ble/GapAdvertisingParams.h"

--- a/source/nRF5xGattServer.cpp
+++ b/source/nRF5xGattServer.cpp
@@ -15,7 +15,11 @@
  */
 
 #include "nRF5xGattServer.h"
-#include "mbed.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed.h"
+#else
+    #include "mbed.h"
+#endif
 
 #include "common/common.h"
 #include "btle/custom/custom_helper.h"

--- a/source/nRF5xn.cpp
+++ b/source/nRF5xn.cpp
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-#include "mbed.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed.h"
+#else
+    #include "mbed.h"
+#endif
 #include "nRF5xn.h"
 #include "ble/blecommon.h"
 #include "nrf_soc.h"


### PR DESCRIPTION
Replace all deprecated inclusions of mbed.h for mbed-drivers/mbed.h when using
mbed OS. Applications should compile for mbed classic.