### PR TITLE
add experimental support for whitelisting

### DIFF
--- a/source/nRF5xGap.cpp
+++ b/source/nRF5xGap.cpp
@@ -234,18 +234,20 @@ ble_error_t nRF5xGap::connect(const Address_t             peerAddr,
     }
 
     ble_gap_scan_params_t scanParams;
-    scanParams.selective   = 0;    /**< If 1, ignore unknown devices (non whitelisted). */
-    scanParams.p_whitelist = NULL; /**< Pointer to whitelist, NULL if none is given. */
     if (scanParamsIn != NULL) {
-        scanParams.active      = scanParamsIn->getActiveScanning();   /**< If 1, perform active scanning (scan requests). */
-        scanParams.interval    = scanParamsIn->getInterval();         /**< Scan interval between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
-        scanParams.window      = scanParamsIn->getWindow();           /**< Scan window between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
-        scanParams.timeout     = scanParamsIn->getTimeout();          /**< Scan timeout between 0x0001 and 0xFFFF in seconds, 0x0000 disables timeout. */
+        scanParams.active      = scanParamsIn->getActiveScanning();      /**< If 1, perform active scanning (scan requests). */
+        scanParams.interval    = scanParamsIn->getInterval();            /**< Scan interval between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
+        scanParams.window      = scanParamsIn->getWindow();              /**< Scan window between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
+        scanParams.timeout     = scanParamsIn->getTimeout();             /**< Scan timeout between 0x0001 and 0xFFFF in seconds, 0x0000 disables timeout. */
+        scanParams.selective   = scanParamsIn->getWhitelist() ? (uint8_t)1 : (uint8_t)0; /**< If 1, ignore unknown devices (non whitelisted). */
+        scanParams.p_whitelist = (ble_gap_whitelist_t*)scanParamsIn->getWhitelist(); /**< Pointer to whitelist, NULL if none is given. */
     } else {
-        scanParams.active      = _scanningParams.getActiveScanning(); /**< If 1, perform active scanning (scan requests). */
-        scanParams.interval    = _scanningParams.getInterval();       /**< Scan interval between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
-        scanParams.window      = _scanningParams.getWindow();         /**< Scan window between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
-        scanParams.timeout     = _scanningParams.getTimeout();        /**< Scan timeout between 0x0001 and 0xFFFF in seconds, 0x0000 disables timeout. */
+        scanParams.active      = _scanningParams.getActiveScanning();    /**< If 1, perform active scanning (scan requests). */
+        scanParams.interval    = _scanningParams.getInterval();          /**< Scan interval between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
+        scanParams.window      = _scanningParams.getWindow();            /**< Scan window between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
+        scanParams.timeout     = _scanningParams.getTimeout();           /**< Scan timeout between 0x0001 and 0xFFFF in seconds, 0x0000 disables timeout. */
+        scanParams.selective   = _scanningParams.getWhitelist() ? (uint8_t)1 : (uint8_t)0; /**< If 1, ignore unknown devices (non whitelisted). */
+        scanParams.p_whitelist = (ble_gap_whitelist_t*)_scanningParams.getWhitelist(); /**< Pointer to whitelist, NULL if none is given. */
     }
 
     uint32_t rc = sd_ble_gap_connect(&addr, &scanParams, &connParams);

--- a/source/nRF5xGap.cpp
+++ b/source/nRF5xGap.cpp
@@ -173,8 +173,8 @@ ble_error_t nRF5xGap::startAdvertising(const GapAdvertisingParams &params)
 
     adv_para.type        = params.getAdvertisingType();
     adv_para.p_peer_addr = NULL;                           // Undirected advertisement
-    adv_para.fp          = BLE_GAP_ADV_FP_ANY;
-    adv_para.p_whitelist = NULL;
+    adv_para.fp          = params.getWhiteList() ? BLE_GAP_ADV_FP_FILTER_BOTH : BLE_GAP_ADV_FP_ANY;
+    adv_para.p_whitelist = (ble_gap_whitelist_t *)params.getWhiteList();
     adv_para.interval    = params.getIntervalInADVUnits(); // advertising interval (in units of 0.625 ms)
     adv_para.timeout     = params.getTimeout();
 

--- a/source/nRF5xGap.h
+++ b/source/nRF5xGap.h
@@ -93,8 +93,8 @@ public:
     virtual ble_error_t startRadioScan(const GapScanningParams &scanningParams) {
         ble_gap_scan_params_t scanParams = {
             .active      = scanningParams.getActiveScanning(), /**< If 1, perform active scanning (scan requests). */
-            .selective   = 0,    /**< If 1, ignore unknown devices (non whitelisted). */
-            .p_whitelist = NULL, /**< Pointer to whitelist, NULL if none is given. */
+            .selective   = scanningParams.getWhitelist() ? (uint8_t)1 : (uint8_t)0, /**< If 1, ignore unknown devices (non whitelisted). */
+            .p_whitelist = (ble_gap_whitelist_t*)scanningParams.getWhitelist(), /**< Pointer to whitelist, NULL if none is given. */
             .interval    = scanningParams.getInterval(),  /**< Scan interval between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
             .window      = scanningParams.getWindow(),    /**< Scan window between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
             .timeout     = scanningParams.getTimeout(),   /**< Scan timeout between 0x0001 and 0xFFFF in seconds, 0x0000 disables timeout. */


### PR DESCRIPTION
@pan- @andresag01

relates to ARMmbed/ble#151
I haven't been able to demonstrate this yet because I don't yet know the APIs to fetch IRKs used in the case of PRIVATE_RESOLVABLE_ADDRs.

refer to https://devzone.nordicsemi.com/question/53432/reading-irk-and-gap_evtparamsconnectedirk_match-issue/?answer=61656#post-id-61656
