### PR TITLE
Fix shutdown of Gap instance to avoid NULL refs

### DIFF
--- a/source/nRF5xn.cpp
+++ b/source/nRF5xn.cpp
@@ -192,6 +192,7 @@ ble_error_t nRF5xn::shutdown(void)
     }
 #endif
 
+    /* Gap instance is always present */
     error = gapInstance.reset();
     if (error != BLE_ERROR_NONE) {
         return error;

--- a/source/nRF5xn.cpp
+++ b/source/nRF5xn.cpp
@@ -53,8 +53,7 @@ nRF5xn& nRF5xn::Instance(BLE::InstanceID_t instanceId)
 nRF5xn::nRF5xn(void) :
     initialized(false),
     instanceID(BLE::DEFAULT_INSTANCE),
-    _gapInstance(),
-    gapInstance(NULL),
+    gapInstance(),
     gattServerInstance(NULL),
     gattClientInstance(NULL),
     securityManagerInstance(NULL)
@@ -193,8 +192,7 @@ ble_error_t nRF5xn::shutdown(void)
     }
 #endif
 
-    /* Gap instance is always present */
-    error = gapInstance->reset();
+    error = gapInstance.reset();
     if (error != BLE_ERROR_NONE) {
         return error;
     }

--- a/source/nRF5xn.h
+++ b/source/nRF5xn.h
@@ -53,10 +53,7 @@ public:
      *        statically.
      */
     virtual Gap &getGap() {
-        if (gapInstance == NULL) {
-            gapInstance = &_gapInstance;
-        }
-        return *gapInstance;
+        return gapInstance;
     };
 
     /**
@@ -116,10 +113,7 @@ public:
      *        internal pointer has been declared mutable.
      */
     virtual const Gap &getGap() const  {
-        if (gapInstance == NULL) {
-            gapInstance = &_gapInstance;
-        }
-        return *gapInstance;
+        return gapInstance;
     };
 
     /**
@@ -166,15 +160,11 @@ private:
     BLE::InstanceID_t instanceID;
 
 private:
-    mutable nRF5xGap _gapInstance; /**< Gap instance whose reference is returned from a call to
-                                    * getGap(). Unlike the GattClient, GattServer and
-                                    * SecurityManager, Gap is always needed in a BLE application. */
+    mutable nRF5xGap gapInstance; /**< Gap instance whose reference is returned from a call to
+                                   * getGap(). Unlike the GattClient, GattServer and
+                                   * SecurityManager, Gap is always needed in a BLE application. */
 
 private:
-    mutable nRF5xGap             *gapInstance;             /**< Pointer to the Gap object instance.
-                                                            *   If NULL, then Gap has not been initialized.
-                                                            *   The pointer has been declared as 'mutable' so that
-                                                            *   it can be assigned inside a 'const' function. */
     mutable nRF5xGattServer      *gattServerInstance;      /**< Pointer to the GattServer object instance.
                                                             *   If NULL, then GattServer has not been initialized.
                                                             *   The pointer has been declared as 'mutable' so that


### PR DESCRIPTION
This should fix the Hard Fault that generated from the following code sequence:
```
ble.init();
ble.shutdown();
```
@LiyouZhou @pan-
