### PR TITLE
Add implementation of experimental whitelisting API

### DIFF
--- a/module.json
+++ b/module.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "ble": "^2.3.0",
-    "nrf51-sdk": "^2.0.0"
+    "nrf51-sdk": "^2.1.0"
   },
   "extraIncludes": [
     "source/btle",

--- a/source/btle/btle_security.cpp
+++ b/source/btle/btle_security.cpp
@@ -43,6 +43,18 @@ static ble_gap_sec_params_t securityParameters = {
     },                             /**< Key distribution bitmap: keys that the peripheral device will distribute. */
 };
 
+ble_error_t btle_createWhitelistFromBonds(ble_gap_whitelist_t *p_whitelist)
+{
+    ret_code_t err = dm_whitelist_create(&applicationInstance, p_whitelist);
+    if (err == NRF_SUCCESS) {
+        return BLE_ERROR_NONE;
+    } else if (err == NRF_ERROR_NULL) {
+        return BLE_ERROR_PARAM_OUT_OF_RANGE;
+    } else {
+        return BLE_ERROR_INVALID_STATE;
+    }
+}
+
 ble_error_t
 btle_initializeSecurity(bool                                      enableBonding,
                         bool                                      requireMITM,

--- a/source/btle/btle_security.cpp
+++ b/source/btle/btle_security.cpp
@@ -45,19 +45,8 @@ static ble_gap_sec_params_t securityParameters = {
     },                             /**< Key distribution bitmap: keys that the peripheral device will distribute. */
 };
 
-ble_error_t btle_createWhitelistFromBondTable(ble_gap_whitelist_t *p_whitelist)
-{
-    ret_code_t err = dm_whitelist_create(&applicationInstance, p_whitelist);
-    if (err == NRF_SUCCESS) {
-        return BLE_ERROR_NONE;
-    } else if (err == NRF_ERROR_NULL) {
-        return BLE_ERROR_PARAM_OUT_OF_RANGE;
-    } else {
-        return BLE_ERROR_INVALID_STATE;
-    }
-}
-
-bool btle_hasInitializedSecurity(void)
+bool
+btle_hasInitializedSecurity(void)
 {
     return initialized;
 }
@@ -281,7 +270,26 @@ dm_handler(dm_handle_t const *p_handle, dm_event_t const *p_event, ret_code_t ev
     return NRF_SUCCESS;
 }
 
-bool btle_matchAddressAndIrk(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_irk)
+ble_error_t
+btle_createWhitelistFromBondTable(ble_gap_whitelist_t *p_whitelist)
 {
+    ret_code_t err = dm_whitelist_create(&applicationInstance, p_whitelist);
+    if (err == NRF_SUCCESS) {
+        return BLE_ERROR_NONE;
+    } else if (err == NRF_ERROR_NULL) {
+        return BLE_ERROR_PARAM_OUT_OF_RANGE;
+    } else {
+        return BLE_ERROR_INVALID_STATE;
+    }
+}
+
+
+bool
+btle_matchAddressAndIrk(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_irk)
+{
+    /*
+     * Use a helper function from the Nordic SDK to test whether the BLE
+     * address can be generated using the IRK.
+     */
     return im_address_resolve(p_addr, p_irk);
 }

--- a/source/btle/btle_security.h
+++ b/source/btle/btle_security.h
@@ -40,7 +40,7 @@ ble_error_t btle_initializeSecurity(bool                                      en
                                     SecurityManager::SecurityIOCapabilities_t iocaps        = SecurityManager::IO_CAPS_NONE,
                                     const SecurityManager::Passkey_t          passkey       = NULL);
 
-ble_error_t btle_createWhitelistFromBonds(ble_gap_whitelist_t *p_whitelist);
+ble_error_t btle_createWhitelistFromBondTable(ble_gap_whitelist_t *p_whitelist);
 
 /**
  * Get the security status of a link.
@@ -76,5 +76,9 @@ ble_error_t btle_setLinkSecurity(Gap::Handle_t connectionHandle, SecurityManager
  *                                    application registration.
  */
 ble_error_t btle_purgeAllBondingState(void);
+
+bool btle_hasInitializedSecurity(void);
+
+bool btle_matchAddressAndIrk(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_irk);
 
 #endif /* _BTLE_SECURITY_H_ */

--- a/source/btle/btle_security.h
+++ b/source/btle/btle_security.h
@@ -21,6 +21,15 @@
 #include "ble/SecurityManager.h"
 
 /**
+ * Function to test whether the SecurityManager has been initialized.
+ * Possible by a call to @ref btle_initializeSecurity().
+ *
+ * @return True if the SecurityManager was previously initialized, false
+ *         otherwise.
+ */
+bool btle_hasInitializedSecurity(void);
+
+/**
  * Enable Nordic's Device Manager, which brings in functionality from the
  * stack's Security Manager. The Security Manager implements the actual
  * cryptographic algorithms and protocol exchanges that allow two devices to
@@ -39,8 +48,6 @@ ble_error_t btle_initializeSecurity(bool                                      en
                                     bool                                      requireMITM   = true,
                                     SecurityManager::SecurityIOCapabilities_t iocaps        = SecurityManager::IO_CAPS_NONE,
                                     const SecurityManager::Passkey_t          passkey       = NULL);
-
-ble_error_t btle_createWhitelistFromBondTable(ble_gap_whitelist_t *p_whitelist);
 
 /**
  * Get the security status of a link.
@@ -78,13 +85,19 @@ ble_error_t btle_setLinkSecurity(Gap::Handle_t connectionHandle, SecurityManager
 ble_error_t btle_purgeAllBondingState(void);
 
 /**
- * Function to test whether the SecurityManager has been initialized.
- * Possible by a call to @ref btle_initializeSecurity().
+ * Query the SoftDevice bond table to extract a whitelist containing the BLE
+ * addresses and IRKs of bonded devices.
  *
- * @return True if the SecurityManager was previously initialized, false
- *         otherwise.
+ * @param[in/out]  p_whitelist
+ *                  (on input) p_whitelist->addr_count and
+ *                  p_whitelist->irk_count specify the maximum number of
+ *                  addresses and IRKs added to the whitelist structure.
+ *                  (on output) *p_whitelist is a whitelist containing the
+ *                  addresses and IRKs of the bonded devices.
+ *
+ * @return BLE_ERROR_NONE Or appropriate error code indicating reason for failure.
  */
-bool btle_hasInitializedSecurity(void);
+ble_error_t btle_createWhitelistFromBondTable(ble_gap_whitelist_t *p_whitelist);
 
 /**
  * Function to test whether a BLE address is generated using an IRK.

--- a/source/btle/btle_security.h
+++ b/source/btle/btle_security.h
@@ -40,6 +40,8 @@ ble_error_t btle_initializeSecurity(bool                                      en
                                     SecurityManager::SecurityIOCapabilities_t iocaps        = SecurityManager::IO_CAPS_NONE,
                                     const SecurityManager::Passkey_t          passkey       = NULL);
 
+ble_error_t btle_createWhitelistFromBonds(ble_gap_whitelist_t *p_whitelist);
+
 /**
  * Get the security status of a link.
  *

--- a/source/btle/btle_security.h
+++ b/source/btle/btle_security.h
@@ -77,8 +77,25 @@ ble_error_t btle_setLinkSecurity(Gap::Handle_t connectionHandle, SecurityManager
  */
 ble_error_t btle_purgeAllBondingState(void);
 
+/**
+ * Function to test whether the SecurityManager has been initialized.
+ * Possible by a call to @ref btle_initializeSecurity().
+ *
+ * @return True if the SecurityManager was previously initialized, false
+ *         otherwise.
+ */
 bool btle_hasInitializedSecurity(void);
 
+/**
+ * Function to test whether a BLE address is generated using an IRK.
+ *
+ * @param[in]   p_addr
+ *                  Pointer to a BLE address.
+ * @param[in]   p_irk
+ *                  Pointer to an IRK.
+ *
+ * @return True if p_addr can be generated using p_irk, false otherwise.
+ */
 bool btle_matchAddressAndIrk(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_irk);
 
 #endif /* _BTLE_SECURITY_H_ */

--- a/source/nRF5xGap.cpp
+++ b/source/nRF5xGap.cpp
@@ -659,12 +659,16 @@ ble_error_t nRF5xGap::setWhitelist(const Gap::Whitelist_t &whitelistIn)
         return BLE_ERROR_PARAM_OUT_OF_RANGE;
     }
 
-    whitelistAddressesSize = 0;
+    /* Test for invalid parameters before we change the internal state */
     for (uint8_t i = 0; i < whitelistIn.size; ++i) {
         if (whitelistIn.addresses[i].type == BLEProtocol::AddressType_t::RANDOM_PRIVATE_NON_RESOLVABLE) {
             /* This is not allowed because it is completely meaningless */
             return BLE_ERROR_INVALID_PARAM;
         }
+    }
+
+    whitelistAddressesSize = 0;
+    for (uint8_t i = 0; i < whitelistIn.size; ++i) {
         memcpy(&whitelistAddresses[whitelistAddressesSize], &whitelistIn.addresses[i], sizeof(BLEProtocol::Address_t));
         whitelistAddressesSize++;
     }

--- a/source/nRF5xGap.cpp
+++ b/source/nRF5xGap.cpp
@@ -642,6 +642,48 @@ Gap::InitiatorPolicyMode_t nRF5xGap::getInitiatorPolicyMode(void) const
     return Gap::INIT_POLICY_IGNORE_WHITELIST;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Helper function used to populate the ble_gap_whitelist_t that
+            will be used by the SoftDevice for filtering requests.
+
+    @param[in]  params
+                Basic advertising details, including the advertising
+                delay, timeout and how the device should be advertised
+    @params[in] advData
+                The primary advertising data payload
+    @params[in] scanResponse
+                The optional Scan Response payload if the advertising
+                type is set to \ref GapAdvertisingParams::ADV_SCANNABLE_UNDIRECTED
+                in \ref GapAdveritinngParams
+
+    @returns    \ref ble_error_t
+
+    @retval     BLE_ERROR_NONE
+                Everything executed properly
+
+    @retval     BLE_ERROR_BUFFER_OVERFLOW
+                The proposed action would cause a buffer overflow.  All
+                advertising payloads must be <= 31 bytes, for example.
+
+    @retval     BLE_ERROR_NOT_IMPLEMENTED
+                A feature was requested that is not yet supported in the
+                nRF51 firmware or hardware.
+
+    @retval     BLE_ERROR_PARAM_OUT_OF_RANGE
+                One of the proposed values is outside the valid range.
+
+    @note  This function is needed because for the BLE API the whitelist
+           is just a collection of keys, but for the stack it also includes
+           the IRK table.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 ble_error_t nRF5xGap::generateStackWhitelist(void)
 {
     ble_gap_whitelist_t  whitelistFromBondTable;

--- a/source/nRF5xGap.cpp
+++ b/source/nRF5xGap.cpp
@@ -573,11 +573,45 @@ void nRF5xGap::getPermittedTxPowerValues(const int8_t **valueArrayPP, size_t *co
     *countP = sizeof(permittedTxValues) / sizeof(int8_t);
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the capacity of the internal whitelist maintained by this
+            implementation.
+
+    @returns    The capacity of the internal whitelist.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 uint8_t nRF5xGap::getMaxWhitelistSize(void) const
 {
     return YOTTA_CFG_WHITELIST_MAX_SIZE;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get a copy of the implementation's internal whitelist.
+
+    @param[out] whitelistOut
+                A \ref Gap::Whitelist_t structure containing a copy of the
+                addresses in the implemenetation's internal whitelist.
+
+    @returns    \ref ble_errror_t
+
+    @retval     BLE_ERROR_NONE
+                Everything executed properly.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 ble_error_t nRF5xGap::getWhitelist(Gap::Whitelist_t &whitelistOut) const
 {
     uint8_t i;
@@ -589,6 +623,36 @@ ble_error_t nRF5xGap::getWhitelist(Gap::Whitelist_t &whitelistOut) const
     return BLE_ERROR_NONE;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the whitelist that will be used in the next call to
+            startAdvertising().
+
+    @param[in]  whitelistIn
+                A reference to a \ref Gap::Whitelist_t structure
+                representing a whitelist containing all the white listed
+                BLE addresses.
+
+    @returns    \ref ble_errror_t
+
+    @retval     BLE_ERROR_NONE
+                Everything executed properly.
+
+                BLE_ERROR_INVALID_PARAM
+                The supplied whitelist contains a private non-resolvable
+                address
+
+                BLE_ERROR_PARAM_OUT_OF_RANGE
+                The size of the supplied whitelist exceeds the maximum
+                capacity of the implementation's internal whitelist.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 ble_error_t nRF5xGap::setWhitelist(const Gap::Whitelist_t &whitelistIn)
 {
     if (whitelistIn.size > getMaxWhitelistSize()) {
@@ -608,6 +672,26 @@ ble_error_t nRF5xGap::setWhitelist(const Gap::Whitelist_t &whitelistIn)
     return BLE_ERROR_NONE;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the advertising policy filter mode that will be used in
+            the next call to startAdvertising().
+
+    @returns    \ref ble_errror_t
+
+    @retval     BLE_ERROR_NONE
+                Everything executed properly.
+
+                BLE_ERROR_NOT_IMPLEMENTED
+                This feature is currently note implemented.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 ble_error_t nRF5xGap::setAdvertisingPolicyMode(Gap::AdvertisingPolicyMode_t mode)
 {
     advertisingPolicyMode = mode;
@@ -615,6 +699,26 @@ ble_error_t nRF5xGap::setAdvertisingPolicyMode(Gap::AdvertisingPolicyMode_t mode
     return BLE_ERROR_NONE;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the scanning policy filter mode that will be used in
+            the next call to startAdvertising().
+
+    @returns    \ref ble_errror_t
+
+    @retval     BLE_ERROR_NONE
+                Everything executed properly.
+
+                BLE_ERROR_NOT_IMPLEMENTED
+                This feature is currently note implemented.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 ble_error_t nRF5xGap::setScanningPolicyMode(Gap::ScanningPolicyMode_t mode)
 {
     scanningPolicyMode = mode;
@@ -622,21 +726,83 @@ ble_error_t nRF5xGap::setScanningPolicyMode(Gap::ScanningPolicyMode_t mode)
     return BLE_ERROR_NONE;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Set the initiator policy filter mode that will be used in
+            the next call to startAdvertising()
+
+    @returns    \ref ble_errror_t
+
+    @retval     BLE_ERROR_NONE
+                Everything executed properly.
+
+                BLE_ERROR_NOT_IMPLEMENTED
+                This feature is currently note implemented.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 ble_error_t nRF5xGap::setInitiatorPolicyMode(Gap::InitiatorPolicyMode_t mode)
 {
     return BLE_ERROR_NOT_IMPLEMENTED;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the current advertising policy filter mode.
+
+    @returns    The advertising policy filter mode.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 Gap::AdvertisingPolicyMode_t nRF5xGap::getAdvertisingPolicyMode(void) const
 {
     return advertisingPolicyMode;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the current scanning policy filter mode.
+
+    @returns    The scanning policy filter mode.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 Gap::ScanningPolicyMode_t nRF5xGap::getScanningPolicyMode(void) const
 {
     return scanningPolicyMode;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Get the current initiator policy filter mode.
+
+    @returns    The initiator policy filter mode.
+
+    @note   Currently initiator filtering using the whitelist is not
+            implemented in this module.
+
+    @section EXAMPLE
+
+    @code
+
+    @endcode
+*/
+/**************************************************************************/
 Gap::InitiatorPolicyMode_t nRF5xGap::getInitiatorPolicyMode(void) const
 {
     return Gap::INIT_POLICY_IGNORE_WHITELIST;
@@ -647,31 +813,16 @@ Gap::InitiatorPolicyMode_t nRF5xGap::getInitiatorPolicyMode(void) const
     @brief  Helper function used to populate the ble_gap_whitelist_t that
             will be used by the SoftDevice for filtering requests.
 
-    @param[in]  params
-                Basic advertising details, including the advertising
-                delay, timeout and how the device should be advertised
-    @params[in] advData
-                The primary advertising data payload
-    @params[in] scanResponse
-                The optional Scan Response payload if the advertising
-                type is set to \ref GapAdvertisingParams::ADV_SCANNABLE_UNDIRECTED
-                in \ref GapAdveritinngParams
-
     @returns    \ref ble_error_t
 
     @retval     BLE_ERROR_NONE
                 Everything executed properly
 
-    @retval     BLE_ERROR_BUFFER_OVERFLOW
-                The proposed action would cause a buffer overflow.  All
-                advertising payloads must be <= 31 bytes, for example.
+    @retval     BLE_ERROR_INVALID_STATE
+                The internal stack was not initialized correctly.
 
-    @retval     BLE_ERROR_NOT_IMPLEMENTED
-                A feature was requested that is not yet supported in the
-                nRF51 firmware or hardware.
-
-    @retval     BLE_ERROR_PARAM_OUT_OF_RANGE
-                One of the proposed values is outside the valid range.
+    @note  Both the SecurityManager and Gap must initialize correctly for
+           this function to succeed.
 
     @note  This function is needed because for the BLE API the whitelist
            is just a collection of keys, but for the stack it also includes

--- a/source/nRF5xGap.cpp
+++ b/source/nRF5xGap.cpp
@@ -440,6 +440,13 @@ ble_error_t nRF5xGap::reset(void)
     /* Clear derived class members */
     m_connectionHandle = BLE_CONN_HANDLE_INVALID;
 
+    /* Set the whitelist policy filter modes to IGNORE_WHITELIST */
+    advertisingPolicyMode = Gap::ADV_POLICY_IGNORE_WHITELIST;
+    scanningPolicyMode    = Gap::SCAN_POLICY_IGNORE_WHITELIST;
+
+    /* Clear the internal whitelist */
+    whitelistAddressesSize = 0;
+
     return BLE_ERROR_NONE;
 }
 

--- a/source/nRF5xGap.cpp
+++ b/source/nRF5xGap.cpp
@@ -168,16 +168,22 @@ ble_error_t nRF5xGap::startAdvertising(const GapAdvertisingParams &params)
         return BLE_ERROR_PARAM_OUT_OF_RANGE;
     }
 
+    /* Allocate the stack's whitelist statically */
+    ble_gap_whitelist_t  whitelist;
+    ble_gap_addr_t      *whitelistAddressPtrs[YOTTA_CFG_WHITELIST_MAX_SIZE];
+    ble_gap_irk_t       *whitelistIrkPtrs[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
+    /* Initialize the whitelist */
+    whitelist.pp_addrs   = whitelistAddressPtrs;
+    whitelist.pp_irks    = whitelistIrkPtrs;
+    whitelist.addr_count = 0;
+    whitelist.irk_count  = 0;
+
     /* Add missing IRKs to whitelist from the bond table held by the SoftDevice */
     if (advertisingPolicyMode != Gap::ADV_POLICY_IGNORE_WHITELIST) {
-        ble_error_t error = generateStackWhitelist();
+        ble_error_t error = generateStackWhitelist(whitelist);
         if (error != BLE_ERROR_NONE) {
             return error;
         }
-    } else {
-        /* Reset the whitelist table to avoid any errors */
-        whitelist.addr_count = 0;
-        whitelist.irk_count  = 0;
     }
 
     /* Start Advertising */
@@ -199,18 +205,24 @@ ble_error_t nRF5xGap::startAdvertising(const GapAdvertisingParams &params)
 
 /* Observer role is not supported by S110, return BLE_ERROR_NOT_IMPLEMENTED */
 #if !defined(TARGET_MCU_NRF51_16K_S110) && !defined(TARGET_MCU_NRF51_32K_S110)
-ble_error_t nRF5xGap::startRadioScan(const GapScanningParams &scanningParams) {
+ble_error_t nRF5xGap::startRadioScan(const GapScanningParams &scanningParams)
+{
+    /* Allocate the stack's whitelist statically */
+    ble_gap_whitelist_t  whitelist;
+    ble_gap_addr_t      *whitelistAddressPtrs[YOTTA_CFG_WHITELIST_MAX_SIZE];
+    ble_gap_irk_t       *whitelistIrkPtrs[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
+    /* Initialize the whitelist */
+    whitelist.pp_addrs   = whitelistAddressPtrs;
+    whitelist.pp_irks    = whitelistIrkPtrs;
+    whitelist.addr_count = 0;
+    whitelist.irk_count  = 0;
 
     /* Add missing IRKs to whitelist from the bond table held by the SoftDevice */
     if (scanningPolicyMode != Gap::SCAN_POLICY_IGNORE_WHITELIST) {
-        ble_error_t error = generateStackWhitelist();
+        ble_error_t error = generateStackWhitelist(whitelist);
         if (error != BLE_ERROR_NONE) {
             return error;
         }
-    } else {
-        /* Reset the whitelist table to avoid any errors */
-        whitelist.addr_count = 0;
-        whitelist.irk_count  = 0;
     }
 
     ble_gap_scan_params_t scanParams = {
@@ -286,16 +298,22 @@ ble_error_t nRF5xGap::connect(const Address_t             peerAddr,
         connParams.conn_sup_timeout  = 600;
     }
 
+    /* Allocate the stack's whitelist statically */
+    ble_gap_whitelist_t  whitelist;
+    ble_gap_addr_t      *whitelistAddressPtrs[YOTTA_CFG_WHITELIST_MAX_SIZE];
+    ble_gap_irk_t       *whitelistIrkPtrs[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
+    /* Initialize the whitelist */
+    whitelist.pp_addrs   = whitelistAddressPtrs;
+    whitelist.pp_irks    = whitelistIrkPtrs;
+    whitelist.addr_count = 0;
+    whitelist.irk_count  = 0;
+
     /* Add missing IRKs to whitelist from the bond table held by the SoftDevice */
     if (scanningPolicyMode != Gap::SCAN_POLICY_IGNORE_WHITELIST) {
-        ble_error_t error = generateStackWhitelist();
+        ble_error_t error = generateStackWhitelist(whitelist);
         if (error != BLE_ERROR_NONE) {
             return error;
         }
-    } else {
-        /* Reset the whitelist table to avoid any errors */
-        whitelist.addr_count = 0;
-        whitelist.irk_count  = 0;
     }
 
     ble_gap_scan_params_t scanParams;
@@ -839,7 +857,7 @@ Gap::InitiatorPolicyMode_t nRF5xGap::getInitiatorPolicyMode(void) const
     @endcode
 */
 /**************************************************************************/
-ble_error_t nRF5xGap::generateStackWhitelist(void)
+ble_error_t nRF5xGap::generateStackWhitelist(ble_gap_whitelist_t &whitelist)
 {
     ble_gap_whitelist_t  whitelistFromBondTable;
     ble_gap_addr_t      *addressPtr[1];

--- a/source/nRF5xGap.h
+++ b/source/nRF5xGap.h
@@ -92,6 +92,10 @@ public:
 
     virtual ble_error_t reset(void);
 
+    /*
+     * The following functions are part of the whitelisting experimental API.
+     * Therefore, this functionality can change in the near future.
+     */
     virtual uint8_t getMaxWhitelistSize(void) const;
     virtual ble_error_t getWhitelist(Gap::Whitelist_t &whitelistOut) const;
     virtual ble_error_t setWhitelist(const Gap::Whitelist_t &whitelistIn);
@@ -118,6 +122,10 @@ public:
 #endif
 
 private:
+    /*
+     * Whitelisting API related structures and helper functions.
+     */
+
     /* Policy modes set by the user. By default these are set to ignore the whitelist */
     Gap::AdvertisingPolicyMode_t advertisingPolicyMode;
     Gap::ScanningPolicyMode_t    scanningPolicyMode;
@@ -139,6 +147,7 @@ private:
      */
     ble_error_t generateStackWhitelist(void);
 
+private:
     bool    radioNotificationCallbackParam; /* parameter to be passed into the Timeout-generated radio notification callback. */
     Timeout radioNotificationTimeout;
 

--- a/source/nRF5xGap.h
+++ b/source/nRF5xGap.h
@@ -28,6 +28,12 @@
     #undef YOTTA_CFG_WHITELIST_MAX_SIZE
     #define YOTTA_CFG_WHITELIST_MAX_SIZE BLE_GAP_WHITELIST_ADDR_MAX_COUNT
 #endif
+#ifndef YOTTA_CFG_IRK_TABLE_MAX_SIZE
+    #define YOTTA_CFG_IRK_TABLE_MAX_SIZE BLE_GAP_WHITELIST_IRK_MAX_COUNT
+#elif YOTTA_CFG_IRK_TABLE_MAX_SIZE > BLE_GAP_WHITELIST_IRK_MAX_COUNT
+    #undef YOTTA_CFG_IRK_TABLE_MAX_SIZE
+    #define YOTTA_CFG_IRK_TABLE_MAX_SIZE BLE_GAP_WHITELIST_IRK_MAX_COUNT
+#endif
 #include "ble/blecommon.h"
 #include "ble.h"
 #include "ble/GapAdvertisingParams.h"
@@ -42,8 +48,6 @@ extern "C" {
 }
 
 #include "btle_security.h"
-
-#include <set>
 
 void radioNotificationStaticCallback(bool param);
 
@@ -88,19 +92,16 @@ public:
 
     virtual ble_error_t reset(void);
 
-    /////////////////// WHITELISTING
-    virtual int8_t getMaxWhitelistSize(void) const;
-    virtual ble_error_t getWhitelist(std::set<BLEProtocol::Address_t> &whitelist) const;
-    virtual ble_error_t setWhitelist(std::set<BLEProtocol::Address_t> whitelist);
+    virtual uint8_t getMaxWhitelistSize(void) const;
+    virtual ble_error_t getWhitelist(Gap::Whitelist_t &whitelistOut) const;
+    virtual ble_error_t setWhitelist(const Gap::Whitelist_t &whitelistIn);
 
-    // Accessors
-    virtual void setAdvertisingPolicyMode(AdvertisingPolicyMode_t mode);
-    virtual void setScanningPolicyMode(ScanningPolicyMode_t mode);
-    virtual void setInitiatorPolicyMode(InitiatorPolicyMode_t mode);
+    virtual ble_error_t setAdvertisingPolicyMode(AdvertisingPolicyMode_t mode);
+    virtual ble_error_t setScanningPolicyMode(ScanningPolicyMode_t mode);
+    virtual ble_error_t setInitiatorPolicyMode(InitiatorPolicyMode_t mode);
     virtual Gap::AdvertisingPolicyMode_t getAdvertisingPolicyMode(void) const;
     virtual Gap::ScanningPolicyMode_t getScanningPolicyMode(void) const;
     virtual Gap::InitiatorPolicyMode_t getInitiatorPolicyMode(void) const;
-    ///////////////////
 
     virtual ble_error_t initRadioNotification(void) {
         if (ble_radio_notification_init(NRF_APP_PRIORITY_HIGH, NRF_RADIO_NOTIFICATION_DISTANCE_800US, radioNotificationStaticCallback) == NRF_SUCCESS) {
@@ -112,47 +113,31 @@ public:
 
 /* Observer role is not supported by S110, return BLE_ERROR_NOT_IMPLEMENTED */
 #if !defined(TARGET_MCU_NRF51_16K_S110) && !defined(TARGET_MCU_NRF51_32K_S110)
-    virtual ble_error_t startRadioScan(const GapScanningParams &scanningParams) {
-        ble_gap_scan_params_t scanParams = {
-            .active      = scanningParams.getActiveScanning(), /**< If 1, perform active scanning (scan requests). */
-            .selective   = scanningPolicyMode,    /**< If 1, ignore unknown devices (non whitelisted). */
-            .p_whitelist = &whitelist, /**< Pointer to whitelist, NULL if none is given. */
-            .interval    = scanningParams.getInterval(),  /**< Scan interval between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
-            .window      = scanningParams.getWindow(),    /**< Scan window between 0x0004 and 0x4000 in 0.625ms units (2.5ms to 10.24s). */
-            .timeout     = scanningParams.getTimeout(),   /**< Scan timeout between 0x0001 and 0xFFFF in seconds, 0x0000 disables timeout. */
-        };
-
-        if (sd_ble_gap_scan_start(&scanParams) != NRF_SUCCESS) {
-            return BLE_ERROR_PARAM_OUT_OF_RANGE;
-        }
-
-        return BLE_ERROR_NONE;
-    }
-
-    virtual ble_error_t stopScan(void) {
-        if (sd_ble_gap_scan_stop() == NRF_SUCCESS) {
-            return BLE_ERROR_NONE;
-        }
-
-        return BLE_STACK_BUSY;
-    }
+    virtual ble_error_t startRadioScan(const GapScanningParams &scanningParams);
+    virtual ble_error_t stopScan(void);
 #endif
 
 private:
-    /////////////////WHITELISTING
+    /* Policy modes set by the user. By default these are set to ignore the whitelist */
     Gap::AdvertisingPolicyMode_t advertisingPolicyMode;
     Gap::ScanningPolicyMode_t    scanningPolicyMode;
-    Gap::InitiatorPolicyMode_t   initiatorPolicyMode; /* Unused */
 
-    ble_gap_addr_t whitelistAddrs[YOTTA_CFG_WHITELIST_MAX_SIZE];
-    ble_gap_addr_t *whitelistAddresses[YOTTA_CFG_WHITELIST_MAX_SIZE];
-    uint8_t        whitelistAddressesSize;
-    ble_gap_irk_t *whitelistIrks[YOTTA_CFG_WHITELIST_MAX_SIZE];
-    uint8_t        whitelistIrksSize;
+    /* Internal representation of a whitelist */
+    uint8_t         whitelistAddressesSize;
+    ble_gap_addr_t  whitelistAddresses[YOTTA_CFG_WHITELIST_MAX_SIZE];
+    ble_gap_addr_t *whitelistAddressPtrs[YOTTA_CFG_WHITELIST_MAX_SIZE];
+    ble_gap_irk_t  *whitelistIrkPtrs[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
 
+    /* Structure used by the SoftDevice to represent a whitelist together with IRK table */
     ble_gap_whitelist_t whitelist;
 
-    /////////////////
+    /*
+     * An internal function used to populate the ble_gap_whitelist_t that will be used by
+     * the SoftDevice for filtering requests. This function is needed because for the BLE
+     * API the whitelist is just a collection of keys, but for the stack it also includes
+     * the IRK table.
+     */
+    ble_error_t generateStackWhitelist(void);
 
     bool    radioNotificationCallbackParam; /* parameter to be passed into the Timeout-generated radio notification callback. */
     Timeout radioNotificationTimeout;
@@ -245,17 +230,15 @@ private:
 
     nRF5xGap() :
         advertisingPolicyMode(Gap::ADV_POLICY_IGNORE_WHITELIST),
-        scanningPolicyMode(Gap::SCAN_POLICY_IGNORE_WHITELIST),
-        initiatorPolicyMode(Gap::INIT_POLICY_IGNORE_WHITELIST),
-        whitelistAddressesSize(0),
-        whitelistIrksSize(0) {
+        scanningPolicyMode(Gap::SCAN_POLICY_IGNORE_WHITELIST) {
         m_connectionHandle = BLE_CONN_HANDLE_INVALID;
 
-        whitelist.pp_addrs = whitelistAddresses;
-        for (int i = 0; i < YOTTA_CFG_WHITELIST_MAX_SIZE; i++) {
-            whitelistAddresses[i] = &(whitelistAddrs[i]);
-        }
-        whitelist.pp_irks  = whitelistIrks;
+        /* Reset the whitelist */
+        whitelist.addr_count   = 0;
+        whitelist.irk_count    = 0;
+        whitelist.pp_irks      = whitelistIrkPtrs;
+        whitelist.pp_addrs     = whitelistAddressPtrs;
+        whitelistAddressesSize = 0;
     }
 
     nRF5xGap(nRF5xGap const &);

--- a/source/nRF5xGap.h
+++ b/source/nRF5xGap.h
@@ -133,11 +133,6 @@ private:
     /* Internal representation of a whitelist */
     uint8_t         whitelistAddressesSize;
     ble_gap_addr_t  whitelistAddresses[YOTTA_CFG_WHITELIST_MAX_SIZE];
-    ble_gap_addr_t *whitelistAddressPtrs[YOTTA_CFG_WHITELIST_MAX_SIZE];
-    ble_gap_irk_t  *whitelistIrkPtrs[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
-
-    /* Structure used by the SoftDevice to represent a whitelist together with IRK table */
-    ble_gap_whitelist_t whitelist;
 
     /*
      * An internal function used to populate the ble_gap_whitelist_t that will be used by
@@ -145,7 +140,7 @@ private:
      * API the whitelist is just a collection of keys, but for the stack it also includes
      * the IRK table.
      */
-    ble_error_t generateStackWhitelist(void);
+    ble_error_t generateStackWhitelist(ble_gap_whitelist_t &whitelist);
 
 private:
     bool    radioNotificationCallbackParam; /* parameter to be passed into the Timeout-generated radio notification callback. */
@@ -239,15 +234,9 @@ private:
 
     nRF5xGap() :
         advertisingPolicyMode(Gap::ADV_POLICY_IGNORE_WHITELIST),
-        scanningPolicyMode(Gap::SCAN_POLICY_IGNORE_WHITELIST) {
+        scanningPolicyMode(Gap::SCAN_POLICY_IGNORE_WHITELIST),
+        whitelistAddressesSize(0) {
         m_connectionHandle = BLE_CONN_HANDLE_INVALID;
-
-        /* Reset the whitelist */
-        whitelist.addr_count   = 0;
-        whitelist.irk_count    = 0;
-        whitelist.pp_irks      = whitelistIrkPtrs;
-        whitelist.pp_addrs     = whitelistAddressPtrs;
-        whitelistAddressesSize = 0;
     }
 
     nRF5xGap(nRF5xGap const &);

--- a/source/nRF5xSecurityManager.h
+++ b/source/nRF5xSecurityManager.h
@@ -19,6 +19,7 @@
 
 #include <stddef.h>
 
+#include "nRF5xGap.h"
 #include "ble/SecurityManager.h"
 #include "btle_security.h"
 
@@ -60,6 +61,10 @@ public:
         return BLE_ERROR_NONE;
     }
 
+    bool hasInitialized(void) const {
+        return btle_hasInitializedSecurity();
+    }
+
 public:
     /*
      * Allow instantiation from nRF5xn when required.
@@ -73,6 +78,15 @@ public:
 private:
     nRF5xSecurityManager(const nRF5xSecurityManager &);
     const nRF5xSecurityManager& operator=(const nRF5xSecurityManager &);
+
+    ble_error_t createWhitelistFromBondTable(ble_gap_whitelist_t &whitelistFromBondTable) const {
+        return btle_createWhitelistFromBondTable(&whitelistFromBondTable);
+    }
+
+    bool matchAddressAndIrk(ble_gap_addr_t *address, ble_gap_irk_t *irk) const {
+        return btle_matchAddressAndIrk(address, irk);
+    }
+    friend class nRF5xGap;
 };
 
 #endif // ifndef __NRF51822_SECURITY_MANAGER_H__

--- a/source/nRF5xSecurityManager.h
+++ b/source/nRF5xSecurityManager.h
@@ -79,13 +79,28 @@ private:
     nRF5xSecurityManager(const nRF5xSecurityManager &);
     const nRF5xSecurityManager& operator=(const nRF5xSecurityManager &);
 
+    /*
+     * Expose an interface that allows us to query the SoftDevice bond table
+     * and extract a whitelist.
+     */
     ble_error_t createWhitelistFromBondTable(ble_gap_whitelist_t &whitelistFromBondTable) const {
         return btle_createWhitelistFromBondTable(&whitelistFromBondTable);
     }
 
+    /*
+     * Given a BLE address and a IRK this function check whether the address
+     * can be generated from the IRK. To do so, this function uses the hash
+     * function and algorithm described in the Bluetooth low Energy
+     * Specification. Internally, Nordic SDK functions are used.
+     */
     bool matchAddressAndIrk(ble_gap_addr_t *address, ble_gap_irk_t *irk) const {
         return btle_matchAddressAndIrk(address, irk);
     }
+
+    /*
+     * Give nRF5xGap access to createWhitelistFromBondTable() and
+     * matchAddressAndIrk()
+     */
     friend class nRF5xGap;
 };
 


### PR DESCRIPTION
This pull request introduces an implementation for nRF51822 based devices to use the whitelisting features of the underlying stack. All functionality introduced by the stack is supported with the exception of initiator whitelisting.

**NOTE:** This pull request must be merged AFTER https://github.com/ARMmbed/nrf51-sdk/pull/15 is published since if uses a couple of functions from the Nordic SDK that were not present in the nrf51-sdk yotta module.

**NOTE:** This pull request lacks the implementation of reset() in nRF5xGap that clears the whitelist on a call to `ble.shutdown()`.

**NOTE:** Both the whitelisting API and this implementation are experimental and might change in the near future.

@pan- 