### PR TITLE
Finish implementation of getAddressesFromBondTable

### DIFF
--- a/source/btle/btle_security.cpp
+++ b/source/btle/btle_security.cpp
@@ -273,6 +273,9 @@ dm_handler(dm_handle_t const *p_handle, dm_event_t const *p_event, ret_code_t ev
 ble_error_t
 btle_createWhitelistFromBondTable(ble_gap_whitelist_t *p_whitelist)
 {
+    if (!btle_hasInitializedSecurity()) {
+        return BLE_ERROR_INITIALIZATION_INCOMPLETE;
+    }
     ret_code_t err = dm_whitelist_create(&applicationInstance, p_whitelist);
     if (err == NRF_SUCCESS) {
         return BLE_ERROR_NONE;

--- a/source/btle/btle_security.cpp
+++ b/source/btle/btle_security.cpp
@@ -293,3 +293,21 @@ btle_matchAddressAndIrk(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_i
      */
     return im_address_resolve(p_addr, p_irk);
 }
+
+void
+btle_generateResolvableAddress(const ble_gap_irk_t &irk, ble_gap_addr_t &address)
+{
+    /* Set type to resolvable */
+    address.addr_type = BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE;
+
+    /*
+     * Assign a random number to the most significant 3 bytes
+     * of the address.
+     */
+    address.addr[BLE_GAP_ADDR_LEN - 3] = 0x8E;
+    address.addr[BLE_GAP_ADDR_LEN - 2] = 0x4F;
+    address.addr[BLE_GAP_ADDR_LEN - 1] = 0x7C;
+
+    /* Calculate the hash and store it in the top half of the address */
+    ah(irk.irk, &address.addr[BLE_GAP_ADDR_LEN - 3], address.addr);
+}

--- a/source/btle/btle_security.h
+++ b/source/btle/btle_security.h
@@ -111,4 +111,18 @@ ble_error_t btle_createWhitelistFromBondTable(ble_gap_whitelist_t *p_whitelist);
  */
 bool btle_matchAddressAndIrk(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_irk);
 
+/**
+ * Function to generate a private resolvable BLE address.
+ *
+ * @param[out]  p_addr
+ *                  The output address.
+ * @param[in]   p_irk
+ *                  A reference to a IRK.
+ *
+ * @note This function does not generate a secure address since the prand number in the
+ *       resolvable address is not truly random. Therefore, the output of this function
+ *       is only meant to be used by the application internally but never exported.
+ */
+void btle_generateResolvableAddress(const ble_gap_irk_t &irk, ble_gap_addr_t &address);
+
 #endif /* _BTLE_SECURITY_H_ */

--- a/source/nRF5xSecurityManager.h
+++ b/source/nRF5xSecurityManager.h
@@ -73,6 +73,7 @@ public:
 
         ble_error_t error = createWhitelistFromBondTable(whitelistFromBondTable);
         if (error != BLE_ERROR_NONE) {
+            addresses.size = 0;
             return error;
         }
 

--- a/source/nRF5xSecurityManager.h
+++ b/source/nRF5xSecurityManager.h
@@ -47,6 +47,70 @@ public:
     }
 
     /**
+     * @brief  Returns a list of addresses from peers in the stacks bond table.
+     *
+     * @param[in/out]   addresses
+     *                  (on input)
+     *                  (on output)
+     *
+     * @return
+     *           BLE_ERROR_NONE if successful.
+     */
+    virtual ble_error_t getAddressesFromBondTable(Gap::Whitelist_t &addresses) const {
+        uint8_t i;
+
+        ble_gap_whitelist_t  whitelistFromBondTable;
+        ble_gap_addr_t      *addressPtr[YOTTA_CFG_WHITELIST_MAX_SIZE];
+        ble_gap_irk_t       *irkPtr[YOTTA_CFG_IRK_TABLE_MAX_SIZE];
+
+        /* Initialize the structure so that we get as many addreses as the whitelist can hold */
+        whitelistFromBondTable.addr_count = YOTTA_CFG_IRK_TABLE_MAX_SIZE;
+        whitelistFromBondTable.pp_addrs   = addressPtr;
+        whitelistFromBondTable.irk_count  = YOTTA_CFG_IRK_TABLE_MAX_SIZE;
+        whitelistFromBondTable.pp_irks    = irkPtr;
+
+        ble_error_t error = createWhitelistFromBondTable(whitelistFromBondTable);
+        if (error != BLE_ERROR_NONE) {
+            return error;
+        }
+
+        /* Put all the addresses in the structure */
+        for (i = 0; i < whitelistFromBondTable.addr_count; ++i) {
+            if (i >= addresses.capacity) {
+                /* Ran out of space in the output Gap::Whitelist_t */
+                addresses.size = i;
+                return BLE_ERROR_NONE;
+            }
+            memcpy(&addresses.addresses[i], whitelistFromBondTable.pp_addrs[i], sizeof(BLEProtocol::Address_t));
+        }
+
+        /* Update the current address count */
+        addresses.size = i;
+
+        /* The assumption here is that the underlying implementation of
+         * createWhitelistFromBondTable()  will not return the private resolvable
+         * addresses (which is the case in the SoftDevice). Rather it returns the
+         * IRKs, so we need to generate the private resolvable address by ourselves.
+         */
+        for (i = 0; i < whitelistFromBondTable.irk_count; ++i) {
+            if (i + addresses.size >= addresses.capacity) {
+                /* Ran out of space in the output Gap::Whitelist_t */
+                addresses.size += i;
+                return BLE_ERROR_NONE;
+            }
+            btle_generateResolvableAddress(
+                *whitelistFromBondTable.pp_irks[i],
+                (ble_gap_addr_t &) addresses.addresses[i + addresses.size]
+            );
+        }
+
+        /* Update the current address count */
+        addresses.size += i;
+
+        return BLE_ERROR_NONE;
+    }
+
+    /**
      * @brief  Clear nRF5xSecurityManager's state.
      *
      * @return

--- a/source/nRF5xSecurityManager.h
+++ b/source/nRF5xSecurityManager.h
@@ -50,8 +50,10 @@ public:
      * @brief  Returns a list of addresses from peers in the stacks bond table.
      *
      * @param[in/out]   addresses
-     *                  (on input)
-     *                  (on output)
+     *                  (on input) @ref Gap::Whitelist_t structure where at
+     *                  most addresses.capacity addresses from bonded peers will
+     *                  be stored.
+     *                  (on output) A copy of the addresses from bonded peers.
      *
      * @return
      *           BLE_ERROR_NONE if successful.


### PR DESCRIPTION
Finish the implementation of the new function getAddressesFromBondTable() in
SecurityManager that returns a table with a list of addresses from the peers
in the bond table.
@pan- 