### PR TITLE
Fix for compilation errors with S110 softdevice in btle.cpp

### DIFF
--- a/source/btle/btle.cpp
+++ b/source/btle/btle.cpp
@@ -189,10 +189,9 @@ static void btle_handler(ble_evt_t *p_ble_evt)
                     break;
             }
 
+#if !defined(TARGET_MCU_NRF51_16K_S110) && !defined(TARGET_MCU_NRF51_32K_S110)
             // Close all pending discoveries for this connection
             nRF5xGattClient& gattClient = ble.getGattClient();
-#if  defined(TARGET_MCU_NRF51_16K_S110) || defined(TARGET_MCU_NRF51_32K_S110)
-#else
             gattClient.characteristicDescriptorDiscoverer().terminate(handle, BLE_ERROR_INVALID_STATE);
             gattClient.discovery().terminate(handle);
 #endif

--- a/source/btle/btle.cpp
+++ b/source/btle/btle.cpp
@@ -191,8 +191,11 @@ static void btle_handler(ble_evt_t *p_ble_evt)
 
             // Close all pending discoveries for this connection
             nRF5xGattClient& gattClient = ble.getGattClient();
+#if  defined(TARGET_MCU_NRF51_16K_S110) || defined(TARGET_MCU_NRF51_32K_S110)
+#else
             gattClient.characteristicDescriptorDiscoverer().terminate(handle, BLE_ERROR_INVALID_STATE);
             gattClient.discovery().terminate(handle);
+#endif
 
             gap.processDisconnectionEvent(handle, reason);
             break;


### PR DESCRIPTION
Now methods that are exclusive to Softdevice S130 are not called when S110 (legacy mode) it's used.

This fix solves the following errors:
-error: 'class nRF5xGattClient' has no member named 'characteristicDescriptorDiscoverer'
-error: 'class nRF5xGattClient' has no member named 'discovery'

Compiled on ubuntu 14.04 with yotta on target mkit-gcc