### PR TITLE
Fix incorrect handles of characteristics descriptors.

### DIFF
--- a/source/nRF5xGattServer.cpp
+++ b/source/nRF5xGattServer.cpp
@@ -133,8 +133,9 @@ ble_error_t nRF5xGattServer::addService(GattService &service)
                                             &nrfDescriptorHandles[descriptorCount]),
                 BLE_ERROR_PARAM_OUT_OF_RANGE);
 
-            p_descriptors[descriptorCount++] = p_desc;
+            p_descriptors[descriptorCount] = p_desc;
             p_desc->setHandle(nrfDescriptorHandles[descriptorCount]);
+            descriptorCount++;
         }
     }
 


### PR DESCRIPTION
The variable descriptorCount is used as an index, and this index is used to set
the handle of the last registered descriptor.

Prior to this fix, descriptorCount was incremented before the handle the update
of the handle of a characteristics.

Short story, all characteristics descriptors handle were equaols to 0 instead
of the actual value.