### PR TITLE
Return an error if the range of attribute to discover is invalid.

### DIFF
--- a/source/nRF5xCharacteristicDescriptorDiscoverer.cpp
+++ b/source/nRF5xCharacteristicDescriptorDiscoverer.cpp
@@ -38,15 +38,10 @@ ble_error_t nRF5xCharacteristicDescriptorDiscoverer::launch(
     Gap::Handle_t descriptorStartHandle = characteristic.getDeclHandle() + 2;
     Gap::Handle_t descriptorEndHandle = characteristic.getLastHandle();
 
-    // check if there is any descriptor to discover
-    if (descriptorEndHandle < descriptorStartHandle) {
-        CharacteristicDescriptorDiscovery::TerminationCallbackParams_t termParams = {
-            characteristic,
-            BLE_ERROR_NONE
-        };
-        terminationCallback.call(&termParams);
-        return BLE_ERROR_NONE;
-    }
+    // check if range is valid
+   if (descriptorEndHandle < descriptorStartHandle) {
+       return BLE_ERROR_PARAM_OUT_OF_RANGE;
+   }
 
     // check if we can run this discovery
     if (isConnectionInUse(connHandle)) {


### PR DESCRIPTION
This PR "fix" https://github.com/ARMmbed/ble-nrf51822/issues/116. 

(There is also a part of ble-cliapp which cause an error regarding this matter).