### PR TITLE
Replace inclusion of nordic header ble.h into nrf_ble.h

### DIFF
--- a/source/btle/btle.h
+++ b/source/btle/btle.h
@@ -24,7 +24,7 @@ extern "C" {
 #include "common/common.h"
 
 #include "ble_srv_common.h"
-#include "ble.h"
+#include "nrf_ble.h"
 
 error_t     btle_init(void);
 

--- a/source/btle/custom/custom_helper.h
+++ b/source/btle/custom/custom_helper.h
@@ -18,7 +18,7 @@
 #define _CUSTOM_HELPER_H_
 
 #include "common/common.h"
-#include "ble.h"
+#include "nrf_ble.h"
 #include "ble/UUID.h"
 #include "ble/GattCharacteristic.h"
 

--- a/source/nRF5xGap.h
+++ b/source/nRF5xGap.h
@@ -35,7 +35,7 @@
     #define YOTTA_CFG_IRK_TABLE_MAX_SIZE BLE_GAP_WHITELIST_IRK_MAX_COUNT
 #endif
 #include "ble/blecommon.h"
-#include "ble.h"
+#include "nrf_ble.h"
 #include "ble/GapAdvertisingParams.h"
 #include "ble/GapAdvertisingData.h"
 #include "ble/Gap.h"

--- a/source/nRF5xGattServer.h
+++ b/source/nRF5xGattServer.h
@@ -20,7 +20,7 @@
 #include <stddef.h>
 
 #include "ble/blecommon.h"
-#include "ble.h" /* nordic ble */
+#include "nrf_ble.h" /* nordic ble */
 #include "ble/Gap.h"
 #include "ble/GattServer.h"
 

--- a/source/nRF5xServiceDiscovery.h
+++ b/source/nRF5xServiceDiscovery.h
@@ -21,7 +21,7 @@
 #include "ble/DiscoveredService.h"
 #include "nRF5xDiscoveredCharacteristic.h"
 
-#include "ble.h"
+#include "nrf_ble.h"
 #include "ble_gattc.h"
 
 class nRF5xGattClient; /* forward declaration */


### PR DESCRIPTION
This change has been introduced in the SDK to mitigate
compilation issues with mbed-classic.

see https://github.com/ARMmbed/nrf51-sdk/pull/26.